### PR TITLE
[ 이태현 ] 기능 추가: User Report Count를 위한 Middleware 추가

### DIFF
--- a/middlewares/reports.js
+++ b/middlewares/reports.js
@@ -1,0 +1,53 @@
+const Sequelize = require('sequelize');
+
+const User = require('../models/users');
+
+
+exports.userReport = async(req, res, next) => {
+    // 테스트를 위해 req.user.id 로 User Id를 받았다.
+    try {
+        user = await User.findOne({where: {id: req.user.id}});
+        user.reportCount = user.reportCount + 1;
+
+        await user.save();
+
+        if (user.reportCount === 5) {
+            user.suspensionCount = user.suspensionCount + 1;
+            user.type = 'suspension'
+
+            await user.save();
+
+            console.log('After Suspended')
+            console.log(user)
+            console.log(user.reportCount)
+            console.log(user.suspensionCount)
+            console.log(user.type)
+            return res.status(200).json(
+                {
+                    code: 200,
+                    message: 'User_Type_Updated'
+                }
+            );
+        } else {
+            console.log('Before Suspended')
+            console.log(user)
+            console.log(user.reportCount)
+            console.log(user.suspensionCount)
+            console.log(user.type)
+            return res.status(200).json(
+                {
+                    code: 200,
+                    message: 'Suspension_Count_Updated'
+                }
+            );
+        }
+    } catch (error) {
+        console.log(error);
+        return res.status(500).json(
+            {
+                code: 500,
+                message: 'SERVER_ERROR'
+            }
+        )
+    }
+};

--- a/routes/user.js
+++ b/routes/user.js
@@ -17,5 +17,4 @@ router.get('/google/callback', socialAuth.googleCallBack);
 router.get('/kakao', socialAuth.kakao);
 router.get('/kakao/callback', socialAuth.kakaoCallBack);
 
-
 module.exports = router;


### PR DESCRIPTION
> HUFS-WEB Project PR message template
아래 사항들을 전부 작성하고 PR 해주세요!

## 구현 사항 간략한 한줄 요약
(여기에 수정 사항에 대한 간략한 한줄 요약/제목 작성해 주세요. 예: 로그인 엔드포인트 구현) 
- 게시글 및 댓글 신고에 따른 User 신고 횟수 증가 및 정지 기능을 위한 미들웨어 추가
		 
## 구현 사항들 자세한 내용
(여기에 수정 사항에 대한 자세한 내용을 작성해 주세요)
- 게시글 및 댓글 신고 횟수가 5회 이상일 경우 자동으로 User 테이블의 reportCount 증가
- reportCount가 5회에 도달 했을 경우 해당 사용자의 suspensionCount를 1회 증가 및 type을 suspension으로 변경
- 5회 미만인 경우 단순 reporCount만 증가

## 구현 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점들 공유해주실 것이 있으면 자유롭게 작성해 주세요.)
- 5회로 고정한 이유는 현재 신고 누적(suspensionCount)에 따른 정지 기간의 범위를 따로 정하지 않아 사용자가 로그인을 시도할 때 User 테이블의 reportCount가 5회가 되어 type이 suspension이 되었을 때 로그인이 안 되게 구현했기 때문이다. 차후 정지 기간 범위가 구체적으로 정해질 경우 해당 조건문을 수정할 예정이다.