### PR TITLE
[ 김하연 ] 기능삭제: 대댓글 parentId 외래키 삭제

### DIFF
--- a/models/replies.js
+++ b/models/replies.js
@@ -31,7 +31,7 @@ module.exports = class Reply extends Sequelize.Model{
     }
     static associate(db){
         db.Reply.belongsTo(db.Post, { onDelete: 'CASCADE', foreignKey: 'postId', targetKey: 'id' });
-        db.Reply.belongsTo(db.Reply, { as: 'ReReply', foreignKey: 'parentId'});
+        //db.Reply.belongsTo(db.Reply, { as: 'ReReply', foreignKey: 'parentId'});
         db.Reply.belongsTo(db.User, { foreignKey: 'userId', targetKey: 'id'});
         db.Reply.hasMany(db.LikeRecordOfReply, { foreignKey: 'replyId', sourceKey: 'id' });
         db.Reply.hasMany(db.ReportOfReply, { foreignKey: 'replyId', sourceKey: 'id' });


### PR DESCRIPTION
> HUFS-WEB Project PR message template
아래 사항들을 전부 작성하고 PR 해주세요!

## 구현 사항 간략한 한줄 요약


		 
## 구현 사항들 자세한 내용
 https://www.notion.so/0417taehyun/77166772905b4bf0aed76cecfc37c5d3?v=c42121f0f5c84dcb972cc071e6d89a86&p=aa12b30d701948e9a1ca569f7ab042f9
- 상위 댓글을 삭제하면 대댓글의 parentId가 null로 업데이트되어 일반 댓글과 대댓글이 구분이 안 되는 문제로 인해 외래키 삭제 진행
- 코드에서 따로 parentId 외래키를 사용하는 곳이 없음
- 상위 댓글을 삭제해도 대댓글의 parentId가 삭제된 id 그대로 남아있게 하기 위함

## 구현 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점들 공유해주실 것이 있으면 자유롭게 작성해 주세요.)

