### PR TITLE
[ 이태현 ] 기능수정: 게시글 조회시 boardId에서 boardTitle로 변경

### DIFF
--- a/controller/board.js
+++ b/controller/board.js
@@ -24,7 +24,8 @@ exports.readPosts = async (req,res,next)=>{
                 COUNT(CASE WHEN replies.id = null THEN 0 ELSE replies.id END) AS "repliesCount"
                 FROM posts
                 LEFT OUTER JOIN replies ON replies.post_id = posts.id
-                WHERE posts.board_id = ${req.params.id}
+                LEFT OUTER JOIN boards ON boards.id = posts.board_id
+                WHERE boards.title = ${req.params.title}
                 GROUP BY posts.id
             `,
             {type: QueryTypes.SELECT}

--- a/routes/board.js
+++ b/routes/board.js
@@ -11,6 +11,6 @@ router.post('/4/post', authUtil.isSignedIn, authUtil.isGraduated, addPost); // �
 
 router.post('/:id/post', authUtil.isSignedIn, authUtil.isAuthorized, addPost); // 일반 게시판 글쓰기
 
-router.get('/:id', authUtil.isSignedIn, authUtil.isAuthorized, readPosts );
+router.get('/:title', authUtil.isSignedIn, authUtil.isAuthorized, readPosts );
 
 module.exports = router;

--- a/routes/post.js
+++ b/routes/post.js
@@ -17,7 +17,7 @@ router.get('/:id/addlike', authUtil.isSignedIn, authUtil.isAuthorized, addLike);
 
 router.post('/:id/report', authUtil.isSignedIn, authUtil.isAuthorized, report);
 
-router.get('/:id', authUtil.isSignedIn, authUtil.isAuthorized, readPost);
+router.get('/:title', authUtil.isSignedIn, authUtil.isAuthorized, readPost);
 router.put('/:id', authUtil.isSignedIn, authUtil.isAuthorized, modifyPost);
 router.delete('/:id', authUtil.isSignedIn, authUtil.isAuthorized, deletePost); 
 

--- a/routes/post.js
+++ b/routes/post.js
@@ -17,7 +17,7 @@ router.get('/:id/addlike', authUtil.isSignedIn, authUtil.isAuthorized, addLike);
 
 router.post('/:id/report', authUtil.isSignedIn, authUtil.isAuthorized, report);
 
-router.get('/:title', authUtil.isSignedIn, authUtil.isAuthorized, readPost);
+router.get('/id', authUtil.isSignedIn, authUtil.isAuthorized, readPost);
 router.put('/:id', authUtil.isSignedIn, authUtil.isAuthorized, modifyPost);
 router.delete('/:id', authUtil.isSignedIn, authUtil.isAuthorized, deletePost); 
 

--- a/routes/post.js
+++ b/routes/post.js
@@ -17,7 +17,7 @@ router.get('/:id/addlike', authUtil.isSignedIn, authUtil.isAuthorized, addLike);
 
 router.post('/:id/report', authUtil.isSignedIn, authUtil.isAuthorized, report);
 
-router.get('/id', authUtil.isSignedIn, authUtil.isAuthorized, readPost);
+router.get('/:id', authUtil.isSignedIn, authUtil.isAuthorized, readPost);
 router.put('/:id', authUtil.isSignedIn, authUtil.isAuthorized, modifyPost);
 router.delete('/:id', authUtil.isSignedIn, authUtil.isAuthorized, deletePost); 
 


### PR DESCRIPTION
> HUFS-WEB Project PR message template
아래 사항들을 전부 작성하고 PR 해주세요!

## 구현 사항 간략한 한줄 요약
(여기에 수정 사항에 대한 간략한 한줄 요약/제목 작성해 주세요. 예: 로그인 엔드포인트 구현) 
- 기존 게시판 아이디를 통한 게시글 조회에서 게시판 이름을 통한 조회로 엔드포인트 로직 변경
		 
## 구현 사항들 자세한 내용
(여기에 수정 사항에 대한 자세한 내용을 작성해 주세요)
- `LEFT OUTER JOIN` 을 사용하여 `boards` 테이블 연결 이후 `where` 절에 `board_id` 대신 `board.title` 사용

## 구현 질문 및 특이 사항
(궁금한 사항들, 하면서 느낀 점들 공유해주실 것이 있으면 자유롭게 작성해 주세요.)
- 현재 라우트에서 `readPost` 에 대해서만 `params` 값을 기존 `:id` 에서 `:title` 로 바꿨습니다. 다른 수정, 삭제 엔드포인트에 대해서는 직접 바꾸시면 될 것 같습니다.

